### PR TITLE
Updating a fix to work with es5 or es6 style templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -10,7 +10,8 @@ const webpackPages = ( globalOptions ) => {
   const generateOutput = ( template, props, options ) => {
     let output = "var React = require( 'react' );";
     output += "var ReactDOM = require( 'react-dom' );";
-    output += "var Element = require( '" + template + "' ).default;";
+    output += "var Element = require( '" + template + "' );";
+    output += "if ( typeof Element.default === 'function' ) Element = Element.default;";
     output += 'var props = ' + JSON.stringify( props ) + ';';
     output += "var renderedElement = ReactDOM.render( <Element {...props} />, document.getElementById( 'content' ));";
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Allows you to use es5 main templates when it comes to how we export modules
#### What tests does this PR have?

Should work alongside the static-site-generator-sites repo
#### How can this be tested?

Run this as a link to the static-site-generator-sites repo

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
