### PR TITLE
Adding option for different endpoints for content

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ npm i
 npm run build
 ```
 
-`src` src param provided for the .md file directory  
-`prismic` prismic param provided for the prismic endpoint  
-`templateDir` templateDir param provided for the template directory  
-`layoutDir` layoutDir param provided for the layouts directory  
-`destination` destination param provided for the output directory  
-`assets` assets param provided for the assets directory  
+`src` src param provided for the .md file directory
+`dataSource` the source to pull the content from as a function (or object as described below)
+`dataSource.type` This can currently be either hxseo or prismic
+`dataSource.url` This is the endpoint url for hxseo or prismic api
+`dataSource.token` This is the token to pass in if the endpoint is private
+`templateDir` templateDir param provided for the template directory
+`layoutDir` layoutDir param provided for the layouts directory
+`destination` destination param provided for the output directory
+`assets` assets param provided for the assets directory
 
-*Optional*  
-You can pass in a `config` param too setup an object used in pages (domain, default agents etc)  
+*Optional*
+You can pass in a `config` param too setup an object used in pages (domain, default agents etc)
 `webpack` is optional if you want to create a common js for the site and page specific js files for isomorphic pages. (This will be a link to the webpack.config.js file)
 
 ## Publishing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -20,9 +20,12 @@
     "node": "0.12.7"
   },
   "dependencies": {
+    "async": "^1.5.2",
     "babel": "^5.8.35",
+    "clone": "^1.0.2",
     "debug": "^2.2.0",
     "fs": "0.0.2",
+    "http": "0.0.0",
     "jsonp": "^0.2.0",
     "meta-marked": "^0.4.0",
     "metalsmith": "^1.3.0",

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -1,0 +1,27 @@
+import prismic from 'metalsmith-prismic';
+import hxseo from './getHXSEOContent';
+
+const getDataSource = ( opts ) => {
+  if ( !opts.dataSource ) return false;
+
+  if ( typeof opts.dataSource === 'function' ) return opts.dataSource;
+
+  // Lets work out the datasource
+  if ( opts.dataSource.type === 'prismic' ) {
+    return prismic({
+      'url': opts.dataSource.url,
+      'linkResolver': function( ctx, doc ) {
+        if ( doc.isBroken ) return '';
+        return '/' + doc.uid;
+      }
+    }, opts.dataSource.token );
+  }
+  if ( opts.dataSource.type === 'hxseo' ) {
+    return hxseo({
+      'url': opts.dataSource.url
+    } );
+  }
+
+};
+
+export default getDataSource;

--- a/src/getHXSEOContent.js
+++ b/src/getHXSEOContent.js
@@ -1,0 +1,48 @@
+import http from 'http';
+import clone from 'clone';
+import async from 'async';
+
+const getHXSEOContent = ( opts ) => {
+
+  return ( files, metalsmith, done ) => {
+
+    const getDataForPage = ( res, fileName, cb ) => {
+      let data = '';
+      res.on( 'data', ( d ) => {
+        data += d;
+      });
+      res.on( 'end', ( ) => {
+        data = JSON.parse( data );
+        for ( let i = 0; i < data.length; i++ ) {
+          let newFile = clone( files[ fileName ] );
+          newFile.pageData = data[i];
+          files[ data[i].pagename + '.html' ] = newFile;
+        }
+        delete files[ fileName ];
+        cb( true );
+      });
+    };
+
+    const callAPI = ( options, fileName, callBack ) => {
+      new Promise( ( resolve ) => {
+        http.get( options, ( res ) => {
+          getDataForPage( res, fileName, resolve );
+        });
+      }).then( ( ) => {
+        callBack( );
+      });
+    };
+
+    async.each( Object.keys( files ), ( fileName, callBack ) => {
+      const fileParams = files[fileName];
+      if ( !fileParams.hxseo ) return callBack( );
+      const options = opts.url;
+      options.path = fileParams.hxseo.query;
+      return callAPI( options, fileName, callBack );
+    }, error => {
+      done( error );
+    });
+  };
+};
+
+export default getHXSEOContent;


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

We needed to allow for some more data sources instead of just prismic, in this case i have added an option called hxseo (To use our existing hxseo database) but also the ability to pass in a dataSource function for you to create your own if needs be.
#### What tests does this PR have?

The normal CI linting currently
#### How can this be tested?

You can download this locally and npm link to the static-site-generator-sites repo to test against existing setup.

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
