### PR TITLE
Updating to allow for subdirectories in build process for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-prismic": "^0.10.0",
     "metalsmith-react-tpl": "^0.2.3",
+    "mkdirp": "^0.5.1",
     "moment": "^2.11.1",
     "path": "^0.12.7",
     "publish": "^0.5.0",

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -3,6 +3,7 @@ import webpack from 'webpack';
 import fs from 'fs';
 import _ from 'underscore';
 import rm from 'rimraf';
+import mkdirp from 'mkdirp';
 
 let outputFiles = { };
 
@@ -17,9 +18,15 @@ const webpackPages = ( globalOptions ) => {
 
     const destFilename = options.destFilename;
     const filename = path.join( options.tempDir, destFilename );
-    if ( !fs.existsSync( path.dirname( filename ) )) fs.mkdirSync( path.dirname( filename ));
+
     outputFiles[ destFilename.replace( '.js', '' ) ] = filename;
-    fs.writeFile( filename, output );
+
+    mkdirp( path.dirname( filename ), err => {
+      if ( err ) return console.log( err );
+      fs.writeFile( filename, output, ( error ) => {
+        if ( error ) return console.log( error );
+      });
+    });
   };
 
   /* Return to metalsmith */

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -49,7 +49,6 @@ const webpackPages = ( globalOptions ) => {
     const finishEach = ( error ) => {
       if ( error !== 'done' ) return done( error );
       globalOptions.webpack.entry = outputFiles;
-      console.log( outputFiles );
       webpack( globalOptions.webpack, err => {
         rm( path.join( metalsmith._directory, '_tempOutput' ), ( ) => { } );
         done( err );


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This allows you to create subdirectories in the build process for webpack, it will use `mkdirp` to build subdirectories from the filename path.
#### What tests does this PR have?

Normal `npm run ci` for linting
#### How can this be tested?

Clone this repo and `npm link` it to the static-site-generator-sites repo to test it locally there with a .md file thats trying to create a page in a subdirectory such like `airport-parking/gatwick.html`
#### What gif best describes how you feel about this work?

![](http://38.media.tumblr.com/76fb2de41cb6e79255933408118472cc/tumblr_nczmveLgKB1s2mpexo1_500.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
