### PR TITLE
Breaking Change: Move to BABEL 6.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:racehorse: Moving to BABEL 6 with new release
#### What does this PR do? (please provide any background)

Bumps the version of the SSG to v3.0.0 due to breaking change of upgrading Babel
#### What tests does this PR have?

None
#### How can this be tested?

`npm run trans` should prove babel compiles.
#### What gif best describes how you feel about this work?

![DOH](https://media.giphy.com/media/32V6UqfX4ffHO/giphy.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2**
- [x] :+1:

**Review 3**
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.
