### PR TITLE
Access token for prismic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -14,7 +14,7 @@ const getDataSource = ( opts ) => {
         if ( doc.isBroken ) return '';
         return '/' + doc.uid;
       }
-    }, opts.dataSource.token );
+    }, opts.dataSource.accessToken );
   }
   if ( opts.dataSource.type === 'hxseo' ) {
     return hxseo({

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -10,11 +10,12 @@ const getDataSource = ( opts ) => {
   if ( opts.dataSource.type === 'prismic' ) {
     return prismic({
       'url': opts.dataSource.url,
+      'accessToken': opts.dataSource.accessToken,
       'linkResolver': function( ctx, doc ) {
         if ( doc.isBroken ) return '';
         return '/' + doc.uid;
       }
-    }, opts.dataSource.accessToken );
+    });
   }
   if ( opts.dataSource.type === 'hxseo' ) {
     return hxseo({


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

We need to pass in the accessToken to the arguments object for metalsmith prismic. Not as a third parameter to the function. This helps Short Breaks authenticate their API correctly via the SSG.
#### What gif best describes how you feel about this work?

![](http://media.giphy.com/media/OTnDHCCFNZHwc/giphy-tumblr.gif)
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Reviewer**
- [x] :+1:
- [ ] I don't think this PR needs any additional reviewers

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
