### PR TITLE
Added ability to add a custom linkResolver via config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "5.0.1",
+  "version": "5.0.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -8,10 +8,11 @@ const getDataSource = ( opts ) => {
 
   // Lets work out the datasource
   if ( opts.dataSource.type === 'prismic' ) {
+    const configLinkResolver = opts.config.linkResolver instanceof Function && opts.config.linkResolver;
     return prismic({
       'url': opts.dataSource.url,
       'accessToken': opts.dataSource.accessToken,
-      'linkResolver': opts.config.linkResolver || function( ctx, doc ) {
+      'linkResolver': configLinkResolver || function( ctx, doc ) {
         if ( doc.isBroken ) return '';
         return '/' + doc.uid;
       }

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -11,7 +11,7 @@ const getDataSource = ( opts ) => {
     return prismic({
       'url': opts.dataSource.url,
       'accessToken': opts.dataSource.accessToken,
-      'linkResolver': function( ctx, doc ) {
+      'linkResolver': opts.config.linkResolver || function( ctx, doc ) {
         if ( doc.isBroken ) return '';
         return '/' + doc.uid;
       }


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Adds the ability to add a custom linkResolver via the brands config file.

#### What tests does this PR have?
#### How can this be tested?

Install in SSG-sites and add a custom linkResolver in the config file. E.g.:

```
linkResolver: function(ctx, doc) {
    if (doc.isBroken) return '';
    // For slugs that are defined in Prismic
    if (doc.data && doc.data.slug && doc.data.slug.json && doc.data.slug.json.value) {
      return doc.data.slug.json.value; 
    }
    // Legacy way of URLs
    return '/' + doc.uid;
}
```

#### What domains are affected?
#### Any tech debt?
#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![]()
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Notes**

When reviewing Static Site Generator projects, please think carefully about what can be done to centralise common functionality. Please also pay attention to anything configurable that will also need updating in the Yeoman generator template

---

**Reviewer**
- [x] :+1:
- [ ] This PR need any additional reviewers!

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.
