### PR TITLE
Changed webpack pages to wait for all files to be written

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -4,37 +4,42 @@ import fs from 'fs';
 import _ from 'underscore';
 import rm from 'rimraf';
 import mkdirp from 'mkdirp';
-import { forEachOf } from 'async';
 
 let outputFiles = { };
 
 const webpackPages = ( globalOptions ) => {
-  const generateOutput = ( template, props, options, next ) => {
-    let output = "var React = require( 'react' );";
-    output += "var ReactDOM = require( 'react-dom' );";
-    output += "var Element = require( '" + template + "' );";
-    output += "if ( typeof Element.default === 'function' ) Element = Element.default;";
-    output += 'var props = ' + JSON.stringify( props ) + ';';
-    output += "var renderedElement = ReactDOM.render( <Element {...props} />, document.getElementById( 'content' ));";
-
-    const destFilename = options.destFilename;
-    const filename = path.join( options.tempDir, destFilename );
-
-    outputFiles[ destFilename.replace( '.js', '' ) ] = filename;
-
-    mkdirp( path.dirname( filename ), err => {
-      if ( err ) return next( err );
-      fs.writeFile( filename, output, ( error ) => {
-        next( error || 'done' );
-      });
-    });
-  };
 
   /* Return to metalsmith */
   return ( files, metalsmith, done ) => {
     if ( !( globalOptions.webpack && globalOptions.dest && globalOptions.directory )) return done();
 
-    const iterator = ( prop, file, next ) => {
+    globalOptions.tempDir = path.join( metalsmith._directory, '_tempOutput' );
+    globalOptions.dest = path.join( metalsmith._directory, globalOptions.dest );
+
+    const generateOutput = ( template, props, options, next ) => {
+      const output = `var React = require( 'react' );
+                      var ReactDOM = require( 'react-dom' );
+                      var Element = require( '${template}' );
+                      if ( typeof Element.default === 'function' ) Element = Element.default;
+                      var props = ${JSON.stringify( props )} ';
+                      var renderedElement = ReactDOM.render( <Element {...props} />, document.getElementById( 'content' ));`;
+
+      const destFilename = options.destFilename;
+      const filename = path.join( options.tempDir, destFilename );
+
+      return new Promise((resolve, reject) => {
+        mkdirp( path.dirname( filename ), error => {
+          if ( error ) return reject( error );
+          fs.writeFile( filename, output, ( error ) => {
+            if (error) return reject(error);
+            outputFiles[ destFilename.replace( '.js', '' ) ] = filename;
+            resolve('done');
+          });
+        });
+      });
+    };
+
+    const iterator = ( prop, file ) => {
       const props = _.extend( { }, prop, metalsmith._metadata );
       props.tpl = ( globalOptions.noConflict ) ? 'rtemplate' : 'template';
       if ( !props[ props.tpl ] ) return;
@@ -43,11 +48,10 @@ const webpackPages = ( globalOptions ) => {
       delete props.mode;
       const template = path.join( metalsmith._directory, globalOptions.directory, props[ props.tpl ] );
       globalOptions.destFilename = file.replace( path.extname( file ), '' ) + '.js';
-      generateOutput( template, props, globalOptions, next );
+      return generateOutput( template, props, globalOptions );
     };
 
-    const finishEach = ( error ) => {
-      if ( error !== 'done' ) return done( error );
+    const finishAll = () => {
       globalOptions.webpack.entry = outputFiles;
       webpack( globalOptions.webpack, err => {
         rm( path.join( metalsmith._directory, '_tempOutput' ), ( ) => { } );
@@ -55,9 +59,19 @@ const webpackPages = ( globalOptions ) => {
       } );
     };
 
-    globalOptions.tempDir = path.join( metalsmith._directory, '_tempOutput' );
-    globalOptions.dest = path.join( metalsmith._directory, globalOptions.dest );
-    forEachOf( files, iterator, finishEach );
+    const promises = Object.keys(files).map(function(key) {
+      const props = files[key];
+      const file = key;
+      return iterator(props, file);
+    });
+
+    // Call the chain
+    Promise
+      .all(promises)
+      .then(finishAll)
+      .catch(function(err) {
+        console.error(err);
+      });
   };
 };
 

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -16,23 +16,23 @@ const webpackPages = ( globalOptions ) => {
     globalOptions.tempDir = path.join( metalsmith._directory, '_tempOutput' );
     globalOptions.dest = path.join( metalsmith._directory, globalOptions.dest );
 
-    const generateOutput = ( template, props, options, next ) => {
+    const generateOutput = ( template, props, options ) => {
       const output = `var React = require( 'react' );
                       var ReactDOM = require( 'react-dom' );
                       var Element = require( '${template}' );
                       if ( typeof Element.default === 'function' ) Element = Element.default;
-                      var props = ${JSON.stringify( props )} ';
+                      var props = ${JSON.stringify( props )};
                       var renderedElement = ReactDOM.render( <Element {...props} />, document.getElementById( 'content' ));`;
 
       const destFilename = options.destFilename;
       const filename = path.join( options.tempDir, destFilename );
+      outputFiles[ destFilename.replace( '.js', '' ) ] = filename;
 
       return new Promise((resolve, reject) => {
         mkdirp( path.dirname( filename ), error => {
           if ( error ) return reject( error );
-          fs.writeFile( filename, output, ( error ) => {
-            if (error) return reject(error);
-            outputFiles[ destFilename.replace( '.js', '' ) ] = filename;
+          fs.writeFile( filename, output, ( err ) => {
+            if (err) return reject(err);
             resolve('done');
           });
         });
@@ -42,7 +42,7 @@ const webpackPages = ( globalOptions ) => {
     const iterator = ( prop, file ) => {
       const props = _.extend( { }, prop, metalsmith._metadata );
       props.tpl = ( globalOptions.noConflict ) ? 'rtemplate' : 'template';
-      if ( !props[ props.tpl ] ) return;
+      if ( !props[ props.tpl ] ) return false;
       delete props.contents;
       delete props.stats;
       delete props.mode;


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

It changes the way that webpackPages handles files. It now uses Promises to make sure it calls Webpack after all files have been written.
This is because we've had issues when creating files with a directory structure that it calls Webpack before the files were done writing, ignoring any files that weren't done yet.

#### What tests does this PR have?
#### How can this be tested?
#### What domains are affected? 
#### Any tech debt?
#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![]()
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Notes**

When reviewing Static Site Generator projects, please think carefully about what can be done to centralise common functionality. Please also pay attention to anything configurable that will also need updating in the Yeoman generator template

---

**Reviewer**
- [ ] :+1:
- [ ] This PR need any additional reviewers!

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.
