### PR TITLE
Underscore clone for Metalsmith-Prismic; Check for props.dataSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/metalsmith-prismic.js
+++ b/src/metalsmith-prismic.js
@@ -4,7 +4,6 @@ var each        = require('async').each
 var Prismic     = require('prismic.io').Prismic
 var debug       = require('debug')('metalsmith-prismic')
 var _           = require('underscore')
-var clone       = require('clone')
 /**
  * Expose `plugin`.
  */
@@ -270,7 +269,7 @@ function plugin(config) {
                 for (var i = 0; i < file.prismic[collectionQuery].results.length; i++) {
 
                     // clone the file and replace the original collectionQuery results with the current result
-                    var newFile = clone(file);
+                    var newFile = _.clone(file);
                     newFile.prismic[collectionQuery].results = [file.prismic[collectionQuery].results[i]];
 
                     // add the filename to the ctx object to make it available for use in the linkResolver function

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -16,7 +16,7 @@ const webpackPages = (globalOptions) => {
     globalOptions.dest = path.join(metalsmith._directory, globalOptions.dest)
 
     const generateOutput = (template, props, options) => {
-      if (props.dataSource.store) {
+      if (props.dataSource && props.dataSource.store) {
         props.store = ''
         if (props.pagename && !props.dataSource.store.includes('../')) {
           props.store = props.pagename.split('/').map(i => '../').join('')


### PR DESCRIPTION
Checking for `props.dataSource` as SB (Prismic) doesn't use this.
Also changing metalsmith prismic to use Underscore clone (`_.clone`) as the original `clone` function takes a whole lot longer (talking 10+ minutes vs ~45 seconds).