### PR TITLE
Added extra option to have markdown directory in a different location

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,10 @@ const MetalSmithLoader = (opts) => {
       webpack: require(path.join(opts.src, opts.webpack))
     }))
 
+  if (opts.markDownSource) {
+    metalSmith.source(opts.markDownSource)
+  }
+
   metalSmith.build(function (err) {
     if (err) throw err
     if (opts.callback) opts.callback()


### PR DESCRIPTION
Option to have markdown coming from somewhere else.
This is so we have different markdown files for different occasions.

For example on SB we want to run a slim version of a markdown file when content is published vs when we want to deploy a styling change that covers the whole website.