### PR TITLE
Swapped _.clone with JSON methods to clone object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/metalsmith-prismic.js
+++ b/src/metalsmith-prismic.js
@@ -269,7 +269,7 @@ function plugin(config) {
                 for (var i = 0; i < file.prismic[collectionQuery].results.length; i++) {
 
                     // clone the file and replace the original collectionQuery results with the current result
-                    var newFile = _.clone(file);
+                    var newFile = JSON.parse(JSON.stringify(file))
                     newFile.prismic[collectionQuery].results = [file.prismic[collectionQuery].results[i]];
 
                     // add the filename to the ctx object to make it available for use in the linkResolver function


### PR DESCRIPTION
Swapped `_.clone` with `JSON.parse(JSON.stringify(x))` as `_.clone` only does a shallow copy and doesn't seem to return all the files needed. The replace functionality does a deep clone, but is still way faster than `npm clone`.