### PR TITLE
Allow link to resolve using slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "8.0.9",
+  "version": "8.0.10",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
     "clone": "^1.0.2",
     "debug": "^2.2.0",
     "jsonp": "^0.2.0",
+    "lodash": "^4.17.21",
     "meta-marked": "^0.4.0",
     "metalsmith": "^2.3.0",
     "metalsmith-assets": "^0.1.0",

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -16,7 +16,7 @@ const getDataSource = (opts) => {
       'accessToken': opts.dataSource.accessToken,
       'linkResolver': configLinkResolver || function (ctx, doc) {
         if (doc.isBroken) return ''
-        if (_.has(doc, 'data.slug.json.value')) { // Node >= 14 - can use instead use: (doc?.data?.slug?.json?.hasOwnProperty('value'))
+        if (_.has(doc, 'data.slug.json.value')) {
           const regExpDomain = new RegExp(`.*${opts.config.domainSettings.domainLive}`)
           // Strip domain (+ everything before it) off of the slug in case it was added by mistake
           const slug = doc.data.slug.json.value

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -1,6 +1,7 @@
 import prismic from './metalsmith-prismic'
 import hxseo from './getHXSEOContent'
 import apiCaller from './apiCaller'
+import _ from 'lodash'
 
 const getDataSource = (opts) => {
   if (!opts.dataSource) return false
@@ -15,6 +16,12 @@ const getDataSource = (opts) => {
       'accessToken': opts.dataSource.accessToken,
       'linkResolver': configLinkResolver || function (ctx, doc) {
         if (doc.isBroken) return ''
+        if (_.has(doc, 'data.slug.json.value')) { // Node >= 14 - can use instead use: (doc?.data?.slug?.json?.hasOwnProperty('value'))
+          const regExpDomain = new RegExp(`.*${opts.config.domainSettings.domainLive}`)
+          // Strip domain (+ everything before it) off of the slug in case it was added by mistake
+          const slug = doc.data.slug.json.value
+          return slug.replace(regExpDomain, '')
+        }
         return '/' + doc.uid
       }
     })


### PR DESCRIPTION
Currently for prismic content - the `linkResolver` function is using `uid` value on the prismic document, however this isn't always the correct value for the page URL - this value can be supplied on the `slug` object - so this change allows the link to be set from there, where provided.

This reuses existing functionality from the [SSG1 repo](https://github.com/holidayextras/static-site-generator-sites/blob/master/templates/paultons/uk/seo/core/config/index.js#L47).