### PR TITLE
Pass 'dataSource' as props down for repos using Prismic as source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -43,10 +43,10 @@
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",
     "debug": "^2.2.0",
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.2.0",
     "standard": "^16.0.4",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.0"

--- a/src/getPrismicContent.js
+++ b/src/getPrismicContent.js
@@ -1,4 +1,5 @@
-const getPrismicContent = () => {
+const getPrismicContent = (coreParams) => {
+  const opts = Object.assign({ }, coreParams)
   return (files, metalsmith, done) => {
     // Adjusts the pageData from prismic to return the value of the fragment instead of the whole entity
     const getFragmentValues = (fragment, file, data) => {
@@ -25,6 +26,7 @@ const getPrismicContent = () => {
     }
 
     Object.keys(files).forEach(file => {
+      files[file].dataSource = opts.dataSource
       files[file].pageData = files[file].prismic.page.results[0].data
       files[file].pagename = file
       getPrismicData(files[file].pageData, file)


### PR DESCRIPTION
Our SSGs are built with server side rendered React.
In order for lifecycle methods, event handlers and other things to work in React client side, you need to use [Reacts hydrate functionality](https://beta.reactjs.org/apis/react-dom/hydrate) (SSG uses an older version).

This repo (static-site-generator) chooses what method to use (render or hydrate), based on config that is passed in through from the SSG repo.
There are 2 files in this repo that handle the content and extend some of the config, the Prismic version isn't extending that config, which means the config needed to decide on the method to use, isn't being passed down.

The work in this PR is to pass down that same config for the SSGs that use Prismic as its source.

To test, look at the PR for [ssg-paultonsbreaks](https://github.com/holidayextras/ssg-paultonsbreaks/pull/103)