### PR TITLE
Add ability to write redirects for Paultons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.1.1",
+  "version": "9.2.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/getDataSource.js
+++ b/src/getDataSource.js
@@ -1,5 +1,6 @@
 import prismic from './metalsmith-prismic'
 import hxseo from './getHXSEOContent'
+import writeRedirect from './writeRedirect'
 import apiCaller from './apiCaller'
 import _ from 'lodash'
 
@@ -16,12 +17,18 @@ const getDataSource = (opts) => {
       accessToken: opts.dataSource.accessToken,
       linkResolver: configLinkResolver || function (ctx, doc) {
         if (doc.isBroken) return ''
+
+        // create redirect script if needed
+        writeRedirect(doc.data)
+
+        // Page url
         if (_.has(doc, 'data.slug.json.value')) {
           const regExpDomain = new RegExp(`.*${opts.config.domainSettings.domainLive}`)
           // Strip domain (+ everything before it) off of the slug in case it was added by mistake
           const slug = doc.data.slug.json.value
           return slug.replace(regExpDomain, '')
         }
+
         return '/' + doc.uid
       }
     })

--- a/src/writeRedirect.js
+++ b/src/writeRedirect.js
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import _ from 'lodash'
 
 const writeRedirect = (documentData) => {
   // Prismic custom field with redirect value

--- a/src/writeRedirect.js
+++ b/src/writeRedirect.js
@@ -9,7 +9,9 @@ const writeRedirect = (documentData) => {
   if (!redirectValue || !pageUrl || !redirectValue.includes('https://')) return
 
   try {
-    const redirectCommand = `aws s3 cp s3://$BUCKET/${pageUrl}.html s3://$BUCKET/${pageUrl}.html --website-redirect ${redirectValue} \n`
+    const redirectCommand = `
+aws s3 cp s3://$BUCKET/${pageUrl}.html s3://$BUCKET/${pageUrl}.html --website-redirect ${redirectValue}
+aws s3 cp s3://$BUCKET/${pageUrl} s3://$BUCKET/${pageUrl} --website-redirect ${redirectValue}`
     if (!fs.existsSync('./bin')) fs.mkdirSync('./bin')
     fs.appendFileSync('./bin/redirects.sh', redirectCommand, { mode: 0o755 })
     console.log(`Added redirect for ${pageUrl} to ${redirectValue}`)

--- a/src/writeRedirect.js
+++ b/src/writeRedirect.js
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import _ from 'lodash'
+
+const writeRedirect = (documentData) => {
+  // Prismic custom field with redirect value
+  const redirectValue = documentData?.redirect?.json?.value
+  // Prismic custom field for slug or UID which every document has by default
+  const pageUrl = documentData?.slug?.json?.value || documentData.uid
+  if (!redirectValue || !pageUrl || !redirectValue.includes('https://')) return
+
+  try {
+    const redirectCommand = `aws s3 cp s3://$BUCKET/${pageUrl}.html s3://$BUCKET/${pageUrl}.html --website-redirect ${redirectValue} \n`
+    if (!fs.existsSync('./bin')) fs.mkdirSync('./bin')
+    fs.appendFileSync('./bin/redirects.sh', redirectCommand, { mode: 0o755 })
+    console.log(`Added redirect for ${pageUrl} to ${redirectValue}`)
+  } catch (err) {
+    console.log(`Writing redirect to bash file for ${pageUrl} has failed.`, err)
+  }
+}
+
+export default writeRedirect


### PR DESCRIPTION
Paultons has its content coming from Prismic.

In Prismic, we have the ability to add a redirect to another page.
To accomplish this technically, it uses an aws s3 redirect added to the file through an aws command.

The code here checks first if we have a redirect value, secondly adds the needed command to a bash file.

This bash file will be optionally read from the [ssg-toolbox on deploy](https://github.com/holidayextras/ssg-toolbox/pull/890).

This can be tested by installing this branch in the ssg-paultonsbreaks repo locally, and running a start command with a page that has a redirect, e.g. `singlePage=unsubscribe npm start landing`.

When the build has finished, check you have a `./bin/redirect.sh` file with content in it.