### PR TITLE
Publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run build
         run: npm run build
+
+      - name: Publish
+        run: npm publish --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,10 @@ jobs:
       - name: Run build
         run: npm run build
 
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/master'
+    steps:
       - name: Publish
         run: npm publish --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Publish
-        run: npm publish --dry-run
+        run: npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=$NPM_TOKEN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Run publish step in master.

Test action run: https://github.com/holidayextras/static-site-generator/actions/runs/10200934197/job/28221617478
This does a dry run publish.

The code has since changed to only publish when a push to master branch happens, which you can see in the last run action.