### PR TITLE
Fix single pages with names that start with the folderPrefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.3.1",
+  "version": "9.4.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/singleFileOnly.js
+++ b/src/singleFileOnly.js
@@ -3,7 +3,8 @@ const singleFileOnly = (opts) => {
     if (!process.env.srcFile && !process.env.singlePage) return done()
     if (process.env.singlePage) {
       Object.keys(files).map(fileName => {
-        const pagePrefix = opts.webpackOptions.folderPrefix ? opts.webpackOptions.folderPrefix.replace(/^\//, '') + '/' : ''
+        const folderPrefix = opts.webpackOptions.folderPrefix ? `${opts.webpackOptions.folderPrefix.replace(/^\//, '')}/` : null
+        const pagePrefix = folderPrefix && !process.env.singlePage.startsWith(folderPrefix) ? folderPrefix : ''
         const singlePage = `${pagePrefix}${process.env.singlePage}.html`
         if (fileName !== singlePage) delete files[fileName]
         return fileName


### PR DESCRIPTION
- What does this PR do? (please provide any background)
When using folders to separate languages on the seo-system we need to use the folderPrefix for the assets to work. That said the static-site-generator adds the folderPrefix to the page name (which already has the folder) when trying to query single pages.
ex: /da/da/koebenhavn
This PR checks if the folderPrefix is already part of the pageName and if so, ignores the folderPrefix to avoid this issue

- What tests does this PR have?
Manual tests when running a singlePage command

- How can this be tested?
Replicating the command to find a single page: 
singlePage=da/koebenhavn npm start locations on the ssg-hx-eu project

- Any tech debt?
No


I have checked our [contributing document](https://github.com/holidayextras/culture/blob/master/blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
By approving a review you are confirming you have...

Witnessed the work behaving as expected (this could be on the author's machine or screencast).
Checked for coding anti-patterns.
Checked for appropriate test coverage.
Checked all the tests are passing.