### PR TITLE
react 16 to react-18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.4.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "async": "^1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,7 +2450,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
       "integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2725,7 +2724,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -4631,7 +4629,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/fill-range": {
@@ -6646,7 +6643,6 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
       "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/nanomatch": {
@@ -7113,7 +7109,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true,
       "optional": true
     },
     "node_modules/path-exists": {
@@ -7841,7 +7836,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/repeat-element": {
@@ -9269,7 +9263,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=4",
@@ -9408,7 +9401,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
       "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
@@ -9418,7 +9410,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "micromatch": "^3.1.4",
@@ -9429,7 +9420,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
@@ -9442,7 +9432,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9452,7 +9441,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "arr-flatten": "^1.1.0",
@@ -9474,7 +9462,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9488,7 +9475,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -9511,7 +9497,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -9525,7 +9510,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -9538,7 +9522,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -9554,7 +9537,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9568,7 +9550,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9586,7 +9567,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -9597,7 +9577,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
@@ -9610,7 +9589,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
@@ -9623,7 +9601,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -9636,7 +9613,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -9649,7 +9625,6 @@
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -9674,7 +9649,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
@@ -9689,7 +9663,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-number": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "license": "MIT",
       "dependencies": {
         "async": "^1.5.2",
@@ -14,7 +14,7 @@
         "meta-marked": "^0.4.0",
         "metalsmith": "^2.3.0",
         "metalsmith-assets-improved": "^1.0.0",
-        "metalsmith-markdown": "^1.1.0",
+        "metalsmith-markdown": "^1.3.0",
         "metalsmith-react-tpl": "^3.0.1",
         "mkdirp": "^0.5.1",
         "prismic.io": "^3.1.3",
@@ -27,10 +27,10 @@
         "@babel/preset-env": "7.25.0",
         "@babel/preset-react": "7.24.7",
         "debug": "^2.2.0",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
-        "react-redux": "^5.0.6",
-        "redux": "^4.2.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-redux": "9.1.2",
+        "redux": "^5.0.0",
         "standard": "^16.0.4",
         "webpack": "^4.23.1",
         "webpack-cli": "^3.1.0"
@@ -1952,6 +1952,13 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -5424,15 +5431,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -5576,15 +5574,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -6461,6 +6450,72 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw=="
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/react-dom/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/react/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/metalsmith-react-tpl/node_modules/scheduler/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/metalsmith-react-tpl/node_modules/semver": {
       "version": "6.3.1",
@@ -7507,38 +7562,30 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-dom/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -7546,37 +7593,28 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
     "node_modules/react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
-      }
-    },
-    "node_modules/react/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-pkg": {
@@ -7695,13 +7733,11 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -8043,20 +8079,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/scheduler/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -9335,6 +9364,16 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "meta-marked": "^0.4.0",
     "metalsmith": "^2.3.0",
     "metalsmith-assets-improved": "^1.0.0",
-    "metalsmith-markdown": "^1.1.0",
+    "metalsmith-markdown": "^1.3.0",
     "metalsmith-react-tpl": "^3.0.1",
     "mkdirp": "^0.5.1",
     "prismic.io": "^3.1.3",
@@ -42,10 +42,10 @@
     "@babel/preset-env": "7.25.0",
     "@babel/preset-react": "7.24.7",
     "debug": "^2.2.0",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
-    "react-redux": "^5.0.6",
-    "redux": "^4.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-redux": "9.1.2",
+    "redux": "^5.0.0",
     "standard": "^16.0.4",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -17,7 +17,7 @@ const webpackPages = (globalOptions) => {
     globalOptions.dest = path.join(metalsmith._directory, globalOptions.dest)
 
     const generateOutput = (template, props, options) => {
-      const method = props.dataSource && props.dataSource.hydrate ? 'hydrate' : 'render'
+      const method = props.dataSource && props.dataSource.hydrate ? 'hydrate' : props.dataSource.hydrateRoot ? 'hydrateRoot' : 'render'
       if (props.dataSource && props.dataSource.store) {
         props.store = props.dataSource.baseFolder || ''
         if (props.pagename && !props.dataSource.store.includes('../')) {
@@ -39,11 +39,26 @@ const webpackPages = (globalOptions) => {
         output += `var Provider = require( 'react-redux' ).Provider;
                    var store = require( '${props.store}' );
                    window.ReactRootProvider = Provider;
+                   window.ReactRootStore = store;`
+        // hydtareRoot(domNode, reactNode) vs hydrate(reactNode, domNode)
+        let output = `var React = require('react');
+                    var ReactDOM = require('react-dom');
+                    var Element = require('${template}');
+                    window.ReactRoot = Element;
+                    if (typeof Element.default === 'function') Element = Element.default;
+                    var props = ${JSON.stringify(props)};
+                    window.ReactRootProps = props;
+                    window.SSGTemplateGroup = '${templateGroup}';`
+      if (props.store) {
+        output += `var Provider = require('react-redux').Provider;
+                   var store = require('${props.store}');
+                   window.ReactRootProvider = Provider;
                    window.ReactRootStore = store;
-                   var renderedElement = ReactDOM.${method}( <Provider store={ store }><Element {...props} /></Provider>, document.getElementById( 'content' ));`
+                   var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Provider store={store}><Element {...props} /></Provider>` : `<Provider store={store}><Element {...props} /></Provider>, ${domNode}`});`
       } else {
-        output += `var renderedElement = ReactDOM.${method}( <Element {...props} />, document.getElementById( 'content' ));`
+        output += `var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Element {...props} />` : `<Element {...props} />, ${domNode}`});`
       }
+    }
 
       const destFilename = options.destFilename
       const filename = path.join(options.tempDir, destFilename)

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -27,19 +27,6 @@ const webpackPages = (globalOptions) => {
       }
       const templateGroups = metalsmith._directory.split('/templates')
       const templateGroup = templateGroups.length > 1 ? '/templates' + templateGroups[1] : (props.group || '')
-      let output = `var React = require( 'react' );
-                    var ReactDOM = require( 'react-dom' );
-                    var Element = require( '${template}' );
-                    window.ReactRoot = Element;
-                    if ( typeof Element.default === 'function' ) Element = Element.default;
-                    var props = ${JSON.stringify(props)};
-                    window.ReactRootProps = props;
-                    window.SSGTemplateGroup = '${templateGroup}';`
-      if (props.store) {
-        output += `var Provider = require( 'react-redux' ).Provider;
-                   var store = require( '${props.store}' );
-                   window.ReactRootProvider = Provider;
-                   window.ReactRootStore = store;`
         // hydtareRoot(domNode, reactNode) vs hydrate(reactNode, domNode)
         let output = `var React = require('react');
                     var ReactDOM = require('react-dom');
@@ -58,7 +45,6 @@ const webpackPages = (globalOptions) => {
       } else {
         output += `var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Element {...props} />` : `<Element {...props} />, ${domNode}`});`
       }
-    }
 
       const destFilename = options.destFilename
       const filename = path.join(options.tempDir, destFilename)

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -27,8 +27,10 @@ const webpackPages = (globalOptions) => {
       }
       const templateGroups = metalsmith._directory.split('/templates')
       const templateGroup = templateGroups.length > 1 ? '/templates' + templateGroups[1] : (props.group || '')
-        // hydtareRoot(domNode, reactNode) vs hydrate(reactNode, domNode)
-        let output = `var React = require('react');
+      const reactNode = '<Element {...props} />'
+      const domNode = 'document.getElementById( \'content\' )'
+      // hydrateRoot(domNode, reactNode) vs hydrate(reactNode, domNode)
+      let output = `var React = require('react');
                     var ReactDOM = require('react-dom');
                     var Element = require('${template}');
                     window.ReactRoot = Element;
@@ -41,9 +43,9 @@ const webpackPages = (globalOptions) => {
                    var store = require('${props.store}');
                    window.ReactRootProvider = Provider;
                    window.ReactRootStore = store;
-                   var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Provider store={store}><Element {...props} /></Provider>` : `<Provider store={store}><Element {...props} /></Provider>, ${domNode}`});`
+                   var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Provider store={store}>${reactNode}</Provider>` : `<Provider store={store}>${reactNode}</Provider>, ${domNode}`});`
       } else {
-        output += `var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, <Element {...props} />` : `<Element {...props} />, ${domNode}`});`
+        output += `var renderedElement = ReactDOM.${method}(${props.dataSource.hydrateRoot ? `${domNode}, ${reactNode}` : `${reactNode}, ${domNode}`});`
       }
 
       const destFilename = options.destFilename


### PR DESCRIPTION
I have tested this pr https://github.com/holidayextras/static-site-generator/pull/95 with all the lib folder to test ssg-hx-uk and static-site-generator sites to use react18.
In this pr updating the version of react and react-dom to 18.2.0 and react-redux to 9.1.2 and redux to 5.0.0. so we can use this version in consuming repo like ssg-purple-parking, ssg-hx-uk and static-site-generator sites . Once this release is mreged to master , then using this version in ssg-purple-parking to use react18.20.0 .We will have testers involved and PM to check the error data etc.