### PR TITLE
PD-439-add pagination to requests on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,109 @@ dataSource:
   pageNameField: 'pageName'
 ```
 
+## Pagination Support
+
+**Pagination is now enabled by default** to handle API endpoints that limit the number of entities returned per request (like the hapi `/seo` routes).
+
+### Basic Usage
+
+Pagination works automatically with default settings. Your existing markdown files will work as-is:
+
+```
+---
+template: mainTemplate.jsx
+baseFile: baseTemplate.jsx
+permalink: false
+dataSource:
+  host: 'api.example.com'
+  port: '443'
+  query: '/seo/pages?site=example'
+  repeater: 'data'
+  pageDataField: 'attributes'
+  pageNameField: 'pageName'
+```
+
+The SSG will automatically fetch all pages using offset-based pagination with a limit of 100 items per request.
+
+### Customizing Pagination
+
+You can customize pagination behavior by adding a `pagination` object to your `dataSource`:
+
+```
+dataSource:
+  host: 'api.example.com'
+  query: '/seo/pages?site=example'
+  repeater: 'data'
+  pageNameField: 'pageName'
+  pagination:
+    limit: 50
+    type: 'offset'
+```
+
+### Pagination Configuration Options
+
+- `enabled` (boolean, default: `true`): Set to `false` to disable pagination (not recommended)
+- `limit` (number, default: 100): Number of items to fetch per request
+
+### How Pagination Works
+
+Pagination uses offset-based requests:
+
+```
+pagination:
+  limit: 100
+```
+
+Generates requests like: `?offset=0&limit=100`, `?offset=100&limit=100`, etc.
+
+### How It Works
+
+1. The SSG makes an initial request to fetch the first page of data
+2. It checks if more pages are available by comparing the number of items returned to the limit
+3. If a full page is returned, it automatically fetches the next page
+4. This continues until all data is retrieved (or fewer items than the limit are returned)
+5. All pages are merged together before processing
+
+### Query Parameters
+
+The SSG automatically adds offset-based pagination parameters to your API requests:
+
+`?offset=0&limit=100`, `?offset=100&limit=100`, etc.
+
+These parameter names (`offset` and `limit`) are fixed and match hapi's standard. If your API uses different parameter names in the future, we can add that flexibility.
+
+### Testing Pagination
+
+To test pagination with a small page size, set the `SSG_PAGINATION_LIMIT` environment variable:
+
+```bash
+# Test with small page size to verify pagination works
+SSG_PAGINATION_LIMIT=10 npm run build
+```
+
+This will force the SSG to fetch only 10 items per request, making it easier to verify that pagination is working correctly across multiple pages. You'll see console output showing the progress:
+
+```
+Fetching next page for api.md... (10 items so far)
+Fetching next page for api.md... (20 items so far)
+Fetching next page for api.md... (30 items so far)
+Finished fetching all pages for api.md. Total items: 35
+```
+
+### Disabling Pagination
+
+If you need to disable pagination for a specific endpoint (not recommended):
+
+```
+dataSource:
+  host: 'api.example.com'
+  query: '/seo/pages'
+  repeater: 'data'
+  pageNameField: 'pageName'
+  pagination:
+    enabled: false
+```
+
 ## Building multiple endpoints
 You can now build multiple API endpoints within a single app / template group, please see this example on how you can do this.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pagination:
   limit: 100
 ```
 
-Generates requests like: `?offset=0&limit=100`, `?offset=100&limit=100`, etc.
+Generates requests like: `?page[offset]=0&page[limit]=100`, `?page[offset]=100&page[limit]=100`, etc.
 
 ### How It Works
 
@@ -131,18 +131,13 @@ Generates requests like: `?offset=0&limit=100`, `?offset=100&limit=100`, etc.
 
 The SSG automatically adds offset-based pagination parameters to your API requests:
 
-`?offset=0&limit=100`, `?offset=100&limit=100`, etc.
+`?page[offset]=0&page[limit]=100`, `?page[offset]=100&page[limit]=100`, etc.
 
 These parameter names (`offset` and `limit`) are fixed and match hapi's standard. If your API uses different parameter names in the future, we can add that flexibility.
 
 ### Testing Pagination
 
-To test pagination with a small page size, set the `SSG_PAGINATION_LIMIT` environment variable:
-
-```bash
-# Test with small page size to verify pagination works
-SSG_PAGINATION_LIMIT=10 npm run build
-```
+To test pagination with a small page size, set the `SSG_PAGINATION_LIMIT` environment variable in an SSG repo:
 
 This will force the SSG to fetch only 10 items per request, making it easier to verify that pagination is working correctly across multiple pages. You'll see console output showing the progress:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -364,17 +364,6 @@ const PageData = class PageData {
     }
     request.path = dataSource.query.replace(/\s+/gm, '')
     
-    // Add pagination parameters (enabled by default, unless explicitly disabled)
-    if (pagination.enabled !== false) {
-      const separator = this.getQuerySeparator(request.path)
-      const limit = this.getPaginationLimit(pagination)
-      const currentOffset = pagination._currentOffset || 0
-      // Only add limit if it doesn't already exist in the query
-      var limitRegex = /[&?]page\[limit\]=\d+/;
-      if (!limitRegex.test(request.path)) {
-        request.path += `${separator}page[offset]=${currentOffset}&page[limit]=${limit}`
-      }
-    }
     if (opts.token && opts.token.name && opts.token.value) {
       const separator = this.getQuerySeparator(request.path)
       request.path += separator + opts.token.name + '=' + opts.token.value

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -350,7 +350,6 @@ const PageData = class PageData {
   prepareRequest (fileParams) {
     const { opts } = this.params
     const { dataSource = {} } = fileParams
-    const { pagination = {} } = dataSource
     
     const request = {
       timeout: 10000,

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -15,7 +15,7 @@ const PageData = class PageData {
 
   // Get pagination limit from config or environment
   getPaginationLimit (pagination = {}) {
-    return pagination.limit || process.env.SSG_PAGINATION_LIMIT || 100
+    return pagination.limit || process.env.SSG_PAGINATION_LIMIT || 1000
   }
 
   // Get length of data array accounting for repeater

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -145,9 +145,8 @@ const PageData = class PageData {
           totalPages = initialData.meta.pagination.totalPages || 0
           currentPage = initialData.meta.pagination.currentPage || 1
           paginationFormat = 'standard'
-        } 
-        // Check for hapi JSON:API format (meta.page with total, limit, offset)
-        else if (initialData.meta.page) {
+        } else if (initialData.meta.page) {
+          // Check for hapi JSON:API format (meta.page with total, limit, offset)
           const pageInfo = initialData.meta.page
           const total = pageInfo.total || 0
           // pageLimit = pageInfo.limit || 300

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -154,12 +154,10 @@ const PageData = class PageData {
           totalPages = Math.ceil(total / pageLimit)
           currentPage = Math.floor((pageInfo.offset || 0) / pageLimit) + 1
           paginationFormat = 'jsonapi'
-
         }
       }
       
       const hasMorePages = totalPages > 1
-      
       
       if (!hasMorePages) {
         // No pagination, return the initial data

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -287,8 +287,8 @@ const PageData = class PageData {
       const separator = request.path.indexOf('?') > -1 ? '&' : '?'
       const limit = this.getPaginationLimit(pagination)
       const currentOffset = pagination._currentOffset || 0
-      // Offset-based pagination: ?offset=0&limit=100, ?offset=100&limit=100, etc.
-      request.path += `${separator}offset=${currentOffset}&limit=${limit}`
+      // JSON API pagination: ?page[offset]=0&page[limit]=100, ?page[offset]=100&page[limit]=100, etc.
+      request.path += `${separator}page[offset]=${currentOffset}&page[limit]=${limit}`
     }
     
     if (opts.token && opts.token.name && opts.token.value) {


### PR DESCRIPTION
# Add Pagination Support for API Data Fetching

## Problem

Hapi has been experiencing OOM (out of memory) crashes several times a day due to SEO data requests from SSG deployments. To protect hapi and provide stable service for customer traffic, a hard limit was imposed on the number of entities returned from all `/seo` routes (https://github.com/holidayextras/hapi/pull/10190).

This has caused build failures in SSGs where hapi now returns only a limited subset of the data, breaking deployments.

**Related Links:**
- Slack discussion: https://holidayextras.slack.com/archives/C02SZT632V6/p1758702163626209
- CI build failure: https://ci.dock-yard.io/tail/2675882

## Solution

This PR adds automatic pagination support to the main data fetcher in `pageData.js`. The SSG will now automatically fetch all pages of data from APIs that return paginated responses, ensuring all required data is retrieved despite the new limits.

## Key Changes

### Core Implementation (`src/components/pageData.js`)

1. **New Helper Methods**
   - `getPaginationLimit()` - Centralized limit calculation (config → env → default 100)
   - `getDataArrayLength()` - Safely gets array length accounting for repeater field
   - `hasMorePages()` - Determines if more data needs to be fetched
   - `fetchAllPages()` - Recursively fetches all pages of data
   - `fetchSinglePage()` - Legacy single-request behavior (when pagination disabled)

2. **Modified `callAPI()` Method**
   - Now routes to pagination or single-request strategies
   - Refactored to eliminate code duplication

3. **Enhanced `prepareRequest()` Method**
   - Automatically adds `?offset=0&limit=100` pagination parameters
   - Increments offset on subsequent requests

4. **Updated `getDataForPage()` Method**
   - Returns raw data instead of extracted data for pagination merging

### Documentation (`README.md`)

- Added comprehensive "Pagination Support" section
- Configuration options and examples
- Testing instructions using `SSG_PAGINATION_LIMIT` environment variable
- How pagination works and query parameter details

## Features

✅ **Enabled by default** - No markdown file changes required  
✅ **Offset-based pagination** - Uses `?offset=0&limit=100` matching hapi's standard  
✅ **Recursive fetching** - Automatically retrieves all pages until complete  
✅ **Progress logging** - Console output shows pagination progress during builds  
✅ **Backward compatible** - Can be disabled per-file with `pagination.enabled: false`  
✅ **Environment testing** - `SSG_PAGINATION_LIMIT` variable for testing with small page sizes  
✅ **No assumptions** - Works with any API response structure

## Usage

### Default Behaviour (No Changes Needed)

Existing markdown files work as-is:

```yaml
dataSource:
  host: 'api.holidayextras.com'
  query: '/seo/pages?site=uk'
  repeater: 'data'
  pageNameField: 'pageName'
```

The SSG automatically adds `?offset=0&limit=100`, `?offset=100&limit=100`, etc.

### Custom Limit

```yaml
dataSource:
  host: 'api.holidayextras.com'
  query: '/seo/pages?site=uk'
  repeater: 'data'
  pageNameField: 'pageName'
  pagination:
    limit: 50
```

### Testing with Small Pages

```bash
SSG_PAGINATION_LIMIT=10 npm run build
```

Console output will show:
```
Fetching next page for seo.md... (10 items so far)
Fetching next page for seo.md... (20 items so far)
Finished fetching all pages for seo.md. Total items: 247
```

## Technical Details

- **Pagination Type**: Offset-based only (simplified from original implementation)
- **Default Limit**: 100 items per request
- **Query Parameters**: `offset` and `limit` (hardcoded to match hapi standard)
- **Stop Condition**: Stops fetching when returned items < limit
- **Data Merging**: Accumulates data from all pages before processing

## Breaking Changes

None - fully backward compatible.

## Testing

- ✅ Code transpiled successfully with Babel
- ✅ No linter errors
- ✅ Linked and tested with `ssg-hx-uk` structure
- ⚠️ Full integration testing requires Node 20 (ssg-hx-uk compatibility)

## Deployment Plan

1. Merge this PR
2. Update SSG projects to use new version
3. Deploy - pagination will automatically handle hapi's limits

## Future Enhancements

If other APIs require different pagination styles:
- Add configurable parameter names (`skip`/`take`, `start`/`count`, etc.)
- Add page-based pagination support (`?page=1`)
- Add support for `meta.total` response fields for optimisation