### PR TITLE
[PD-439] implement hapi pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.3.0",
+  "version": "9.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.3.0",
+      "version": "9.5.0",
       "license": "MIT",
       "dependencies": {
         "async": "^1.5.2",
@@ -108,6 +108,7 @@
       "version": "7.24.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
       "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -2125,6 +2126,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2145,6 +2147,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2450,7 +2453,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
       "integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2725,7 +2727,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -2886,6 +2887,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001640",
         "electron-to-chromium": "^1.4.820",
@@ -3849,6 +3851,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
       "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.3.0",
@@ -4018,6 +4021,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
       "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
@@ -4117,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
       "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "eslint-plugin-es": "^3.0.0",
         "eslint-utils": "^2.0.0",
@@ -4155,6 +4160,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.1.tgz",
       "integrity": "sha512-XgdcdyNzHfmlQyweOPTxmc7pIsS6dE4MvwhXWMQ2Dxs1XAL2GJDilUsjWen6TWik0aSI+zD/PqocZBblcm9rdA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       },
@@ -4167,6 +4173,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.3.tgz",
       "integrity": "sha512-ZMbFvZ1WAYSZKY662MBVEWR45VaBT6KSJCiupjrNlcdakB90juaZeDCbJq19e73JZQubqFtgETohwgAt8u5P6w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
@@ -4631,7 +4638,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/fill-range": {
@@ -6646,7 +6652,6 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
       "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/nanomatch": {
@@ -7113,7 +7118,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true,
       "optional": true
     },
     "node_modules/path-exists": {
@@ -7515,6 +7519,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7704,6 +7709,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -7841,7 +7847,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/repeat-element": {
@@ -9269,7 +9274,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=4",
@@ -9408,7 +9412,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
       "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
@@ -9418,7 +9421,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "micromatch": "^3.1.4",
@@ -9429,7 +9431,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
@@ -9442,7 +9443,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9452,7 +9452,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "arr-flatten": "^1.1.0",
@@ -9474,7 +9473,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9488,7 +9486,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -9511,7 +9508,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -9525,7 +9521,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -9538,7 +9533,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -9554,7 +9548,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9568,7 +9561,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9586,7 +9578,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -9597,7 +9588,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.0"
@@ -9610,7 +9600,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
@@ -9623,7 +9612,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -9636,7 +9624,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -9649,7 +9636,6 @@
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -9674,7 +9660,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
@@ -9689,7 +9674,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "is-number": "^3.0.0",
@@ -9703,6 +9687,7 @@
       "version": "4.47.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.47.0.tgz",
       "integrity": "sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -70,7 +70,7 @@ const PageData = class PageData {
       : `http://${host}:${port}${query}`
 
     const opts = this.params.opts
-    if (opts && opts.token && opts.token.name && opts.token.value) {
+    if (opts?.token?.name && opts.token.value) {
       const delimiter = url.includes('?') ? '&' : '?'
       url += `${delimiter}${opts.token.name}=${opts.token.value}`
     }

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -93,7 +93,7 @@ const PageData = class PageData {
     throw new Error('No response found')
   }
 
-  async makeExtraAPICalls (data, fileParams, callBack) {
+  makeExtraAPICalls (data, fileParams, callBack) {
     // Now check for additional requests per page returned from API call
     // This can be prodlib data based on an SEO object
     if (!fileParams.dataSource.extras) return callBack()

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -1,4 +1,4 @@
-import { fetchHapiPaginated } from './pagination.js'
+import { fetchWithPagination } from './pagination.js'
 import pageNameChanger from './pageNameChanger'
 import pageNameSanitiser from './pageNameSanitiser'
 
@@ -80,7 +80,7 @@ const PageData = class PageData {
   // Call the API per markdown file and get data for each one returned.
   async callAPI (fileName, fileParams) {
     const url = this._buildUrl(fileParams)
-    const data = await fetchHapiPaginated(url)
+    const data = await fetchWithPagination(url)
 
     if (data) {
       const response = this.extractData(data, fileName, fileParams) // removed repeater because hapi always returns 'data' (hapi responseHelper._generateResponse)... rather than whatever is in repeater field, so its useless
@@ -114,7 +114,7 @@ const PageData = class PageData {
         fileParams.dataSource = fileParams // Needs to double up for functions
 
         const url = this._buildUrl(fileParams)
-        const paginatedData = await fetchHapiPaginated(url)
+        const paginatedData = await fetchWithPagination(url)
         if (paginatedData) {
           const response = this.extractData({ data: paginatedData }, currentFile.key, fileParams)
           this.params.files[currentFile.key][opt] = response.data

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -1,5 +1,3 @@
-import http from 'http'
-import https from 'https'
 import { fetchHapiPaginated } from './pagination.js'
 import pageNameChanger from './pageNameChanger'
 import pageNameSanitiser from './pageNameSanitiser'
@@ -61,16 +59,16 @@ const PageData = class PageData {
   }
 
   // Helper to build the full API URL for a file's dataSource
-  _buildUrl(fileParams) {
+  _buildUrl (fileParams) {
     const host = fileParams.dataSource.host
     const query = fileParams.dataSource.query
     const port = fileParams.dataSource.port || '443'
-    
+
     // Use https if port is 443, otherwise use http with port
     let url = (port === '443')
       ? `https://${host}${query}`
       : `http://${host}:${port}${query}`
-    
+
     const opts = this.params.opts
     if (opts && opts.token && opts.token.name && opts.token.value) {
       const delimiter = url.includes('?') ? '&' : '?'
@@ -80,21 +78,22 @@ const PageData = class PageData {
   }
 
   // Call the API per markdown file and get data for each one returned.
-  async callAPI(fileName, fileParams) {
+  async callAPI (fileName, fileParams) {
     const url = this._buildUrl(fileParams)
     const data = await fetchHapiPaginated(url)
 
     if (data) {
       const response = this.extractData(data, fileName, fileParams) // removed repeater because hapi always returns 'data' (hapi responseHelper._generateResponse)... rather than whatever is in repeater field, so its useless
-      
+
       delete this.params.files[fileName] // Remove the markdown file from metalsmith as its not an actual page
-      if (response?.response)
+      if (response?.response) {
         return response.response
+      }
     }
     throw new Error('No response found')
   }
 
-  async makeExtraAPICalls(data, fileParams, callBack) {
+  async makeExtraAPICalls (data, fileParams, callBack) {
     // Now check for additional requests per page returned from API call
     // This can be prodlib data based on an SEO object
     if (!fileParams.dataSource.extras) return callBack()

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -80,10 +80,10 @@ const PageData = class PageData {
   // Call the API per markdown file and get data for each one returned.
   async callAPI (fileName, fileParams) {
     const url = this._buildUrl(fileParams)
-    const data = await fetchWithPagination(url)
+    const data = await fetchWithPagination(url, fileParams?.dataSource?.repeater || 'data')
 
     if (data) {
-      const response = this.extractData(data, fileName, fileParams) // removed repeater because hapi always returns 'data' (hapi responseHelper._generateResponse)... rather than whatever is in repeater field, so its useless
+      const response = this.extractData(data, fileName, fileParams)
 
       delete this.params.files[fileName] // Remove the markdown file from metalsmith as its not an actual page
       if (response?.response) {
@@ -114,7 +114,7 @@ const PageData = class PageData {
         fileParams.dataSource = fileParams // Needs to double up for functions
 
         const url = this._buildUrl(fileParams)
-        const paginatedData = await fetchWithPagination(url)
+        const paginatedData = await fetchWithPagination(url, fileParams?.dataSource?.repeater || 'data')
         if (paginatedData) {
           const response = this.extractData({ data: paginatedData }, currentFile.key, fileParams)
           this.params.files[currentFile.key][opt] = response.data

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -2,8 +2,7 @@
 
 async function fetchHapiPaginated (url, timeout = 10000) {
   const newUrl = new URL(url)
-  const originalLimit = parseInt(newUrl.searchParams.get('page[limit]'), 10) || 1000 // default to 1000 as thats current HAPI limit...
-  newUrl.searchParams.set('page[limit]', 1000) // bit of tech debt to force a limit of 1000 as hapi bug expects 1000
+  const originalLimit = parseInt(newUrl.searchParams.get('page[limit]'), 10) || 50 // default to 50 as JSONAPI will default to 50 if undefined
 
   return await fetchWithPagination(newUrl.toString(), originalLimit, timeout)
 }

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -10,10 +10,10 @@ async function fetchHapiPaginated (url, timeout = 10000) {
 /**
  * Pagination utility that fetches all data from a cursor-based API endpoint using links.next.
  *
- * @param {string} baseUrl - The API endpoint URL (can include query parameters)
+ * @param {string} hapiUrl - The API endpoint URL (can include query parameters)
  * @param {number} pageLimit - Maximum number of items to fetch
  * @param {number} timeout - Request timeout in ms (default: 10000)
- * @returns {Promise<Array>} - Flattened array of all paginated results
+ * @returns {Promise<Array|null>} - Flattened array of all paginated results, or null if no results found
  */
 async function fetchWithPagination (hapiUrl, pageLimit, timeout = 10000) {
   const controller = new AbortController()

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,33 +1,29 @@
 /* global fetch, AbortController */
 
-async function fetchHapiPaginated (url, timeout = 10000) {
-  const newUrl = new URL(url)
-  const originalLimit = parseInt(newUrl.searchParams.get('page[limit]'), 10) || 50 // default to 50 as JSONAPI will default to 50 if undefined
-
-  return await fetchWithPagination(newUrl.toString(), originalLimit, timeout)
-}
-
 /**
- * Pagination utility that fetches all data from a cursor-based API endpoint using links.next.
+ * Paginated fetch all data using links.next in response
  *
  * @param {string} hapiUrl - The API endpoint URL (can include query parameters)
- * @param {number} pageLimit - Maximum number of items to fetch
- * @param {number} timeout - Request timeout in ms (default: 10000)
- * @returns {Promise<Array|null>} - Flattened array of all paginated results, or null if no results found
+ * @param {number} timeout - Per-request timeout in ms (default: 10000)
+ * @returns {Promise<Array|null>} - Flattened array of all paginated data, or null if no results found
  */
-async function fetchWithPagination (hapiUrl, pageLimit, timeout = 10000) {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeout)
-
+async function fetchWithPagination (hapiUrl, timeout = 10000) {
   const allResults = []
   let currentUrl = hapiUrl
 
-  try {
-    while (currentUrl && allResults.length < pageLimit) {
+  while (currentUrl) {
+    // Create a new AbortController for each request
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+    try {
       const response = await fetch(currentUrl, {
         headers: { accept: 'application/json' },
         signal: controller.signal
       })
+
+      // Clear timeout since request completed
+      clearTimeout(timeoutId)
 
       if (!response.ok) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -46,26 +42,25 @@ async function fetchWithPagination (hapiUrl, pageLimit, timeout = 10000) {
       // Always expect 'data' in response and next page in 'links.next'
       const pageData = responseData.data
 
-      if (Array.isArray(pageData) && pageData.length > 0) {
+      if (Array.isArray(pageData)) {
         for (const item of pageData) {
-          if (allResults.length >= pageLimit) break
           allResults.push(item)
         }
       }
 
       // Get the next page URL
       currentUrl = responseData.links?.next
+    } catch (error) {
+      // Clear timeout on error
+      clearTimeout(timeoutId)
+      if (error.name === 'AbortError') {
+        throw new Error(`Request timeout after ${timeout}ms`)
+      }
+      throw error
     }
-
-    return allResults.length > 0 ? allResults : null
-  } catch (error) {
-    if (error.name === 'AbortError') {
-      throw new Error(`Request timeout after ${timeout}ms`)
-    }
-    throw error
-  } finally {
-    clearTimeout(timeoutId)
   }
+
+  return allResults.length > 0 ? allResults : null
 }
 
-export { fetchHapiPaginated }
+export { fetchWithPagination }

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,0 +1,72 @@
+async function fetchHapiPaginated(url, timeout = 10000) {
+  const newUrl = new URL(url)
+  const originalLimit = parseInt(newUrl.searchParams.get('page[limit]'), 10) || 1000 // default to 1000 as thats current HAPI limit...
+  newUrl.searchParams.set('page[limit]', 1000) // bit of tech debt to force a limit of 1000 as hapi bug expects 1000
+  
+  return await fetchWithPagination(newUrl.toString(), originalLimit, timeout)
+}
+
+/**
+ * Pagination utility that fetches all data from a cursor-based API endpoint using links.next.
+ *
+ * @param {string} baseUrl - The API endpoint URL (can include query parameters)
+ * @param {number} pageLimit - Maximum number of items to fetch
+ * @param {number} timeout - Request timeout in ms (default: 10000)
+ * @returns {Promise<Array>} - Flattened array of all paginated results
+ */
+async function fetchWithPagination(hapiUrl, pageLimit, timeout = 10000) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+  let allResults = []
+  let currentUrl = hapiUrl
+
+  try {
+    while (currentUrl && allResults.length < pageLimit) {
+      const response = await fetch(currentUrl, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+      }
+
+      const responseData = await response.json()
+
+      if (!responseData) {
+        throw new Error('Empty response from API')
+      }
+
+      if (responseData.message) {
+        throw new Error(responseData.message)
+      }
+
+      // Always expect 'data' in response and next page in 'links.next'
+      const pageData = responseData.data
+
+      if (Array.isArray(pageData) && pageData.length > 0) {
+        for (const item of pageData) {
+          if (allResults.length >= pageLimit) break
+          allResults.push(item)
+        }
+      }
+
+      // Get the next page URL
+      currentUrl = responseData.links?.next
+    }
+
+    return allResults.length > 0 ? allResults : null
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timeout after ${timeout}ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+
+
+export { fetchHapiPaginated }

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,8 +1,10 @@
-async function fetchHapiPaginated(url, timeout = 10000) {
+/* global fetch, AbortController */
+
+async function fetchHapiPaginated (url, timeout = 10000) {
   const newUrl = new URL(url)
   const originalLimit = parseInt(newUrl.searchParams.get('page[limit]'), 10) || 1000 // default to 1000 as thats current HAPI limit...
   newUrl.searchParams.set('page[limit]', 1000) // bit of tech debt to force a limit of 1000 as hapi bug expects 1000
-  
+
   return await fetchWithPagination(newUrl.toString(), originalLimit, timeout)
 }
 
@@ -14,11 +16,11 @@ async function fetchHapiPaginated(url, timeout = 10000) {
  * @param {number} timeout - Request timeout in ms (default: 10000)
  * @returns {Promise<Array>} - Flattened array of all paginated results
  */
-async function fetchWithPagination(hapiUrl, pageLimit, timeout = 10000) {
+async function fetchWithPagination (hapiUrl, pageLimit, timeout = 10000) {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeout)
 
-  let allResults = []
+  const allResults = []
   let currentUrl = hapiUrl
 
   try {
@@ -66,7 +68,5 @@ async function fetchWithPagination(hapiUrl, pageLimit, timeout = 10000) {
     clearTimeout(timeoutId)
   }
 }
-
-
 
 export { fetchHapiPaginated }

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -90,13 +90,14 @@ const webpackPages = (globalOptions) => {
           if (globalOptions.callback) return globalOptions.callback(err)
           throw err
         }
-        const info = stats.toJson()
         if (stats.hasErrors()) {
-          console.log(info.errors)
-          globalOptions.callback(new Error(info.errors[0]))
+          const errors = stats.compilation.errors
+          console.log(errors)
+          globalOptions.callback(new Error(errors[0]))
+        } else {
+          rm(path.join(metalsmith._directory, '_tempOutput'), () => { })
+          if (globalOptions.callback) globalOptions.callback(null, Object.keys(outputFiles))
         }
-        rm(path.join(metalsmith._directory, '_tempOutput'), () => { })
-        if (globalOptions.callback) globalOptions.callback(null, Object.keys(outputFiles))
       })
     }
 

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -94,10 +94,9 @@ const webpackPages = (globalOptions) => {
           const errors = stats.compilation.errors
           console.log(errors)
           globalOptions.callback(new Error(errors[0]))
-        } else {
-          rm(path.join(metalsmith._directory, '_tempOutput'), () => { })
-          if (globalOptions.callback) globalOptions.callback(null, Object.keys(outputFiles))
         }
+        rm(path.join(metalsmith._directory, '_tempOutput'), () => { })
+        if (globalOptions.callback) globalOptions.callback(null, Object.keys(outputFiles))
       })
     }
 

--- a/src/webpackPages.js
+++ b/src/webpackPages.js
@@ -93,7 +93,7 @@ const webpackPages = (globalOptions) => {
         if (stats.hasErrors()) {
           const errors = stats.compilation.errors
           console.log(errors)
-          globalOptions.callback(new Error(errors[0]))
+          globalOptions.callback(errors[0])
         }
         rm(path.join(metalsmith._directory, '_tempOutput'), () => { })
         if (globalOptions.callback) globalOptions.callback(null, Object.keys(outputFiles))


### PR DESCRIPTION
main part of the work for [PD-439](https://holidayextras.jira.com/browse/PD-439)
outline: https://holidayextras.getoutline.com/doc/pd-439-sBrUYP0wA2

### what does this do
implemented pagination.js & updated pageData.js to use it - also added some logging for debugging
fixed issue in webpackPages.js which was causing large spikes in memory usage due to creating massive json objects

### how to run
1. build `lib` folder by following command:
```sh
git fetch && git checkout PD-439 && nvm use && npm i && npm run build
```
2. to get this running, go to ssg- repo such as `ssg-hx-uk`
3. then navigate to node_modules folder and search for @holidayextras/static-site-generator.
4. replace lib folder in there with the one you built

so now you you can run ssg-hx-uk running with these local changes, for example using:
```sh
npm start content
```

you should see logs that pagination is working
and also allow build to run, should see pages open.

[PD-439]: https://holidayextras.jira.com/browse/PD-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ