### PR TITLE
Check pagination response returns page data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.6.1",
+      "version": "9.6.2",
       "license": "MIT",
       "dependencies": {
         "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -50,10 +50,12 @@ async function fetchWithPagination (hapiUrl, repeater = 'data', timeout = 10000)
       }
 
       // Calculate pagination request numbers from offset, limit, and total
-      const pageMeta = responseData.meta.page
-      const currentRequest = Math.floor(pageMeta.offset / pageMeta.limit) + 1
-      const totalRequests = Math.ceil(pageMeta.total / pageMeta.limit)
-      console.log(`[Pagination] Fetched ${(currentRequest / totalRequests * 100).toFixed(0)}% from ${currentUrl}`)
+      const pageMeta = responseData.meta?.page
+      if (pageMeta) { // check there is page data
+        const currentRequest = Math.floor(pageMeta.offset / pageMeta.limit) + 1
+        const totalRequests = Math.ceil(pageMeta.total / pageMeta.limit)
+        console.log(`[Pagination] Fetched ${(currentRequest / totalRequests * 100).toFixed(0)}% from ${currentUrl}`)
+      }
 
       // Get the next page URL
       currentUrl = responseData.links?.next

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -40,6 +40,10 @@ async function fetchWithPagination (hapiUrl, repeater = 'data', timeout = 10000)
         throw new Error(responseData.message)
       }
 
+      if (!responseData.meta?.page) {
+        throw new Error('No page data found in response')
+      }
+
       // Expect data in response and next page in 'links.next'
       const pageData = responseData[repeater]
 
@@ -50,12 +54,10 @@ async function fetchWithPagination (hapiUrl, repeater = 'data', timeout = 10000)
       }
 
       // Calculate pagination request numbers from offset, limit, and total
-      const pageMeta = responseData.meta?.page
-      if (pageMeta) { // check there is page data
-        const currentRequest = Math.floor(pageMeta.offset / pageMeta.limit) + 1
-        const totalRequests = Math.ceil(pageMeta.total / pageMeta.limit)
-        console.log(`[Pagination] Fetched ${(currentRequest / totalRequests * 100).toFixed(0)}% from ${currentUrl}`)
-      }
+      const pageMeta = responseData.meta.page
+      const currentRequest = Math.floor(pageMeta.offset / pageMeta.limit) + 1
+      const totalRequests = Math.ceil(pageMeta.total / pageMeta.limit)
+      console.log(`[Pagination] Fetched ${(currentRequest / totalRequests * 100).toFixed(0)}% from ${currentUrl}`)
 
       // Get the next page URL
       currentUrl = responseData.links?.next

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -40,14 +40,14 @@ async function fetchWithPagination (hapiUrl, repeater = 'data', timeout = 10000)
         throw new Error(responseData.message)
       }
 
-      if (!responseData.meta?.page) {
-        throw new Error('No page data found in response')
-      }
-
       // Expect data in response and next page in 'links.next'
       const pageData = responseData[repeater]
 
       if (Array.isArray(pageData)) {
+        if (pageData.length === 0) {
+          throw new Error('No data found in response')
+        }
+
         for (const item of pageData) {
           allResults.push(item)
         }


### PR DESCRIPTION
Fixing a bit of tech debt as part of PD-2024. 

This error occurs when the url we are querying returns with an empty data array from HAPI, hence not returning any meta data for the page. 
This usually happens when a query filter is invalid, or a page being specified doesn't exist in the HAPI database. 

Some parts within the SSG process end up querying HAPI with such pages that don't exist

For example you can see here there are many errors for pages that don't exist:
https://ci.dock-yard.io/tail/2842096

`filter[pageName]=flughafenhotel-amsterdam/kundenbewertungen/videos` which relates to the page https://www.holidayextras.com/de/flughafenhotel-amsterdam/kundenbewertungen/videos.html

Basically some pages don't contain all the necessary things and this code accounts for this
