### PR TITLE
Add static-site-generator to github registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # static-site-generator Changelog
 
+## v9.7.0
+Add `publishConfig.registry` for GitHub Packages (@holidayextras). Bump minor for publish.
+
 ## v9.6.5
 Update all packages to the latest available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # static-site-generator Changelog
 
-## v9.7.0
-Add `publishConfig.registry` for GitHub Packages (@holidayextras). Bump minor for publish.
+## v9.6.6
+Add `publishConfig.registry` for GitHub Packages (@holidayextras).
 
 ## v9.6.5
 Update all packages to the latest available

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.7.0",
+  "version": "9.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.7.0",
+      "version": "9.6.6",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.5",
+  "version": "9.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.6.5",
+      "version": "9.7.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.7.0",
+  "version": "9.6.6",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.5",
+  "version": "9.7.0",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",
@@ -49,6 +49,9 @@
     "standard": "^17.1.2",
     "webpack": "^5.105.4",
     "webpack-cli": "^6.0.1"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/@holidayextras"
   },
   "owner": "audience"
 }


### PR DESCRIPTION
This pr adds the config so that static-site-generator is published under the github registry