### PR TITLE
Add logging to help with debugging and update logic so that failed qu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # static-site-generator Changelog
 
+## v9.6.7
+PageData: use Promise.allSettled so all files are processed before returning (avoids returning early on first failure and losing successful results). Delete md file when no dataSource or on API error. Add [pageData] logging for API result and each md-file removal reason.
+
 ## v9.6.6
 Add `publishConfig.registry` for GitHub Packages (@holidayextras).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holidayextras/static-site-generator",
-      "version": "9.6.6",
+      "version": "9.6.7",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/static-site-generator",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "description": "Holiday Extras Static Site Generator in metalsmith / react",
   "repository": {
     "type": "git",

--- a/src/components/pageData.js
+++ b/src/components/pageData.js
@@ -82,6 +82,8 @@ const PageData = class PageData {
     const url = this._buildUrl(fileParams)
     const data = await fetchWithPagination(url, fileParams?.dataSource?.repeater || 'data')
 
+    console.log('[pageData] API result for', fileName, ':', data === null ? 'null' : data === undefined ? 'undefined' : Array.isArray(data) ? 'array length ' + data.length : typeof data, Array.isArray(data) && data.length > 0 ? '(first item keys: ' + Object.keys(data[0]).join(', ') + ')' : '')
+
     if (data) {
       const response = this.extractData(data, fileName, fileParams)
 
@@ -90,7 +92,7 @@ const PageData = class PageData {
         return response.response
       }
     }
-    // Remove this md file so the pipeline does not see an orphan (avoids "No outputFiles for webpack" when another file succeeded)
+    console.log('[pageData] Deleting md file (no response / empty):', fileName)
     delete this.params.files[fileName]
     throw new Error('No response found')
   }
@@ -158,26 +160,40 @@ const PageData = class PageData {
       return new Promise((resolve, reject) => {
         let fileParams = this.params.files[fileName]
         if (this.params.opts.initSetup) fileParams = this.params.opts.initSetup(fileParams)
-        if (!fileParams.dataSource) return reject(new Error('SSG Error: no dataSource'))
+        if (!fileParams.dataSource) {
+          console.log('[pageData] Deleting md file (no dataSource):', fileName)
+          delete this.params.files[fileName]
+          return reject(new Error('SSG Error: no dataSource'))
+        }
         if (process.env.singlePage) fileParams.dataSource.query = this.singlePageReduce(fileParams.dataSource.query)
         if (!fileParams.dataSource.query) {
+          console.log('[pageData] Deleting md file (query empty after singlePage reduce):', fileName)
           delete this.params.files[fileName]
           return resolve()
         }
         const queryKey = fileParams.dataSource.query
         if (process.env.singlePage && querySeen[queryKey]) {
+          console.log('[pageData] Deleting md file (duplicate query, skipping API call):', fileName)
           delete this.params.files[fileName]
           return resolve()
         }
         if (process.env.singlePage) querySeen[queryKey] = true
         return this.callAPI(fileName, fileParams).then(data => {
           this.makeExtraAPICalls(data, fileParams, resolve)
-        }).catch(reject)
+        }).catch(err => {
+          console.log('[pageData] Deleting md file (API error):', fileName)
+          delete this.params.files[fileName]
+          reject(err)
+        })
       })
     })
-    return Promise.all(fetchedPageData).then(() => {
-      return this.returnFiles()
-    }).catch(() => {
+    // Use allSettled so we wait for every file to finish (resolve or reject) before returning.
+    // Promise.all would reject on first failure and return early, leaving other in-flight requests' mutations lost.
+    return Promise.allSettled(fetchedPageData).then((results) => {
+      const rejected = results.filter(r => r.status === 'rejected')
+      if (rejected.length > 0) {
+        console.error('[pageData] Some files failed:', rejected.map(r => r.reason?.message || r.reason))
+      }
       return this.returnFiles()
     })
   }


### PR DESCRIPTION
This PR adds a bunch of logging to help identify queries that fail or return nothing and thus are removed from the final result.
It also makes it so if multiple query files are sent, they all finish before checking which ones failed as it might be the expected result (singlePage for instance)